### PR TITLE
Adds the alert content type

### DIFF
--- a/config/block.block.views_block__alerts_block_1.yml
+++ b/config/block.block.views_block__alerts_block_1.yml
@@ -1,0 +1,24 @@
+uuid: d4e200f4-e2b3-4e05-b854-0016b64f6290
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.alerts
+  module:
+    - views
+  theme:
+    - bartik
+id: views_block__alerts_block_1
+theme: bartik
+region: highlighted
+weight: 0
+provider: null
+plugin: 'views_block:alerts-block_1'
+settings:
+  id: 'views_block:alerts-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/config/core.base_field_override.node.alert.promote.yml
+++ b/config/core.base_field_override.node.alert.promote.yml
@@ -1,0 +1,22 @@
+uuid: 0c7e4a3d-b41a-4629-ba3b-31826f36ee3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.alert
+id: node.alert.promote
+field_name: promote
+entity_type: node
+bundle: alert
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.entity_form_display.node.alert.default.yml
+++ b/config/core.entity_form_display.node.alert.default.yml
@@ -1,0 +1,73 @@
+uuid: e4fa50cd-f920-4123-b9be-5ed2581a40f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.alert.body
+    - field.field.node.alert.field_effective_dates
+    - field.field.node.alert.field_sitewide
+    - node.type.alert
+  module:
+    - datetime_range
+    - text
+id: node.alert.default
+targetEntityType: node
+bundle: alert
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 1
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_effective_dates:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
+  field_sitewide:
+    weight: 3
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 6
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 4
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden:
+  path: true
+  promote: true
+  sticky: true

--- a/config/core.entity_view_display.node.alert.default.yml
+++ b/config/core.entity_view_display.node.alert.default.yml
@@ -1,0 +1,32 @@
+uuid: 2cf3b6b9-84ac-4267-b009-f0145b682d07
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.alert.body
+    - field.field.node.alert.field_effective_dates
+    - field.field.node.alert.field_sitewide
+    - node.type.alert
+  module:
+    - text
+    - user
+id: node.alert.default
+targetEntityType: node
+bundle: alert
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_effective_dates: true
+  field_sitewide: true

--- a/config/core.entity_view_display.node.alert.teaser.yml
+++ b/config/core.entity_view_display.node.alert.teaser.yml
@@ -1,0 +1,30 @@
+uuid: 6ab62166-edd6-48b3-a743-dfe195d30d6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.alert.body
+    - node.type.alert
+  module:
+    - text
+    - user
+id: node.alert.teaser
+targetEntityType: node
+bundle: alert
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -11,6 +11,7 @@ module:
   contact: 0
   contextual: 0
   datetime: 0
+  datetime_range: 0
   dblog: 0
   dynamic_page_cache: 0
   editor: 0

--- a/config/field.field.node.alert.body.yml
+++ b/config/field.field.node.alert.body.yml
@@ -1,0 +1,22 @@
+uuid: 7e6b8410-2742-46eb-b948-fc4f28aed07d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.alert
+  module:
+    - text
+id: node.alert.body
+field_name: body
+entity_type: node
+bundle: alert
+label: Body
+description: 'If a longer statement is needed than just the headline, put it here.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.alert.field_effective_dates.yml
+++ b/config/field.field.node.alert.field_effective_dates.yml
@@ -1,0 +1,21 @@
+uuid: fec39f20-1d15-4fae-a4c9-15533fe7e9ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_effective_dates
+    - node.type.alert
+  module:
+    - datetime_range
+id: node.alert.field_effective_dates
+field_name: field_effective_dates
+entity_type: node
+bundle: alert
+label: 'Effective Dates'
+description: 'This defines the start and end time for displaying this alert.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/config/field.field.node.alert.field_sitewide.yml
+++ b/config/field.field.node.alert.field_sitewide.yml
@@ -1,0 +1,23 @@
+uuid: 176b9dfd-e450-4602-ad6d-21c178508cb3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sitewide
+    - node.type.alert
+id: node.alert.field_sitewide
+field_name: field_sitewide
+entity_type: node
+bundle: alert
+label: Sitewide
+description: 'Should this alert be displayed on all site pages?'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/field.storage.node.field_effective_dates.yml
+++ b/config/field.storage.node.field_effective_dates.yml
@@ -1,0 +1,20 @@
+uuid: ffe0cba6-6bb3-425b-a06d-8411d8af15dd
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_effective_dates
+field_name: field_effective_dates
+entity_type: node
+type: daterange
+settings:
+  datetime_type: date
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_sitewide.yml
+++ b/config/field.storage.node.field_sitewide.yml
@@ -1,0 +1,18 @@
+uuid: f83c0a29-b0bd-4027-a1cd-b6da3a4d880a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_sitewide
+field_name: field_sitewide
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/node.type.alert.yml
+++ b/config/node.type.alert.yml
@@ -1,0 +1,17 @@
+uuid: 962a8bad-39c9-4db6-813d-800b4ba46940
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Alert
+type: alert
+description: 'Use an alert to display urgent messages across the website. They can be targeted for the entire site, or (eventually) just for certain sections.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/user.role.contributor.yml
+++ b/config/user.role.contributor.yml
@@ -6,4 +6,7 @@ id: contributor
 label: Contributor
 weight: 4
 is_admin: null
-permissions: {  }
+permissions:
+  - 'create alert content'
+  - 'delete own alert content'
+  - 'edit own alert content'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -6,4 +6,11 @@ id: editor
 label: Editor
 weight: 3
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access content overview'
+  - 'create alert content'
+  - 'delete any alert content'
+  - 'edit any alert content'
+  - 'edit own alert content'
+  - 'revert alert revisions'
+  - 'view alert revisions'

--- a/config/views.view.alerts.yml
+++ b/config/views.view.alerts.yml
@@ -1,0 +1,326 @@
+uuid: 9ade3679-0711-4d06-a0c9-ef0b1e3b60bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.alert
+  module:
+    - datetime
+    - node
+    - text
+    - user
+id: alerts
+label: Alerts
+module: views
+description: 'This view displays currently-active alerts on the site.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            alert: alert
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_effective_dates_value:
+          id: field_effective_dates_value
+          table: node__field_effective_dates
+          field: field_effective_dates_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+        field_effective_dates_end_value:
+          id: field_effective_dates_end_value
+          table: node__field_effective_dates
+          field: field_effective_dates_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: Alerts
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'


### PR DESCRIPTION
This defines the Alert content type and associated configuration, including:

- Creates a few fields that are used by Alerts
- Defines permissions for Editors and Contributors over Alerts
- Creates a View and Block for displaying Alerts in a rudimentary fashion

I should note that there are some differences in the content modeling between this and the Sanity demo. Sanity doesn't appear to support the notion of a date range, so the begin/end times in Sanity are separate fields. Drupal _does_ have a date range, so I've used only one field for that here.

In terms of permissions, the following should be true:
- Admins and Editors can do everything with Alerts (create, edit, delete, revert, etc)
- Contributors can create, edit, and delete only their own Alerts
- Idea Bank contributors can't do anything with Alerts

The full permissions grid (accessible to admins) is visible at `/admin/people/permissions` in any Drupal app.
